### PR TITLE
switch Maven Central artifact repository URL to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <repository>
             <id>thingsboard-repo-deploy</id>

--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
                     <version>${spring-boot.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.fortasoft</groupId>
+                    <groupId>org.thingsboard</groupId>
                     <artifactId>gradle-maven-plugin</artifactId>
-                    <version>1.0.8</version>
+                    <version>1.0.9</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -391,7 +391,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.fortasoft</groupId>
+                <groupId>org.thingsboard</groupId>
                 <artifactId>gradle-maven-plugin</artifactId>
                 <configuration>
                     <tasks>


### PR DESCRIPTION
https://blog.sonatype.com/central-repository-moving-to-https